### PR TITLE
DocExtract: many improvements

### DIFF
--- a/refextract/documents/pdf.py
+++ b/refextract/documents/pdf.py
@@ -36,6 +36,7 @@ replace in plain-text.
 
 from __future__ import absolute_import, print_function, unicode_literals
 
+import os
 import re
 import subprocess
 
@@ -483,6 +484,9 @@ def convert_PDF_to_plaintext(fpath, keep_layout=False):
     @return: (list) of unicode strings (contents of the PDF file translated
     into plaintext; each string is a line in the document.)
     """
+    if not os.path.isfile(CFG_PATH_PDFTOTEXT):
+        raise Exception('Missing pdftotext executable')
+
     if keep_layout:
         layout_option = "-layout"
     else:

--- a/refextract/documents/text.py
+++ b/refextract/documents/text.py
@@ -242,7 +242,7 @@ def get_page_break_positions(docbody):
     p_break = re.compile(ur'^\s*\f\s*$', re.UNICODE)
     num_document_lines = len(docbody)
     for i in xrange(num_document_lines):
-        if p_break.match(docbody[i]) != None:
+        if p_break.match(docbody[i]) is not None:
             page_break_posns.append(i)
     return page_break_posns
 

--- a/refextract/references/api.py
+++ b/refextract/references/api.py
@@ -196,15 +196,10 @@ def extract_journal_reference(line, override_kbs_files=None):
     Extracts the journal reference from string and parses for specific
     journal information.
     """
-    tagged_line = tag_reference_line(
-        line, get_kbs(custom_kbs_files=override_kbs_files), {}
-    )[0]
-    if tagged_line is None:
-        return None
+    kbs = get_kbs(custom_kbs_files=override_kbs_files)
+    references, dummy_m, dummy_c, dummy_co = parse_reference_line(line, kbs)
 
-    elements, dummy_marker, dummy_stats = parse_tagged_reference_line(
-        '', tagged_line, [], [])
-
-    for element in elements:
-        if element['type'] == 'JOURNAL':
-            return element
+    for elements in references:
+        for el in elements:
+            if el['type'] == 'JOURNAL':
+                return el

--- a/refextract/references/config.py
+++ b/refextract/references/config.py
@@ -58,6 +58,7 @@ CFG_REFEXTRACT_FIELDS = {
     'misc': 'm',
     'linemarker': 'o',
     'doi': 'a',
+    'hdl': 'a',
     'reportnumber': 'r',
     'journal': 's',
     'url': 'u',

--- a/refextract/references/find.py
+++ b/refextract/references/find.py
@@ -65,29 +65,29 @@ def find_reference_section(docbody):
     title_patterns = get_reference_section_title_patterns()
 
     # Try to find refs section title:
-    for reversed_index, line in enumerate(reversed(docbody)):
-        title_match = regex_match_list(line, title_patterns)
-        if title_match:
-            title = title_match.group('title')
-            index = len(docbody) - 1 - reversed_index
-            temp_ref_details, found_title = find_numeration(
-                docbody[index:index + 6], title)
-            if temp_ref_details:
-                if ref_details and 'title' in ref_details \
-                        and ref_details['title'] \
-                        and not temp_ref_details['title']:
-                    continue
-                if ref_details and 'marker' in ref_details \
-                        and ref_details['marker'] \
-                        and not temp_ref_details['marker']:
-                    continue
+    for title_pattern in title_patterns:
+        # Look for title pattern in docbody
+        for reversed_index, line in enumerate(reversed(docbody)):
+            title_match = title_pattern.match(line)
+            if title_match:
+                title = title_match.group('title')
+                index = len(docbody) - 1 - reversed_index
+                temp_ref_details, found_title = find_numeration(docbody[index:index + 6], title)
+                if temp_ref_details:
+                    if ref_details and 'title' in ref_details and ref_details['title'] and not temp_ref_details['title']:
+                        continue
+                    if ref_details and 'marker' in ref_details and ref_details['marker'] and not temp_ref_details['marker']:
+                        continue
 
-                ref_details = temp_ref_details
-                ref_details['start_line'] = index
-                ref_details['title_string'] = title
+                    ref_details = temp_ref_details
+                    ref_details['start_line'] = index
+                    ref_details['title_string'] = title
 
-            if found_title:
-                break
+                if found_title:
+                    break
+
+        if ref_details:
+            break
 
     return ref_details
 

--- a/refextract/references/kbs.py
+++ b/refextract/references/kbs.py
@@ -300,7 +300,7 @@ def build_reportnum_kb(fpath):
             for classification in preprint_classifications:
                 search_pattern_str = ur'(?:^|[^a-zA-Z0-9\/\.\-])([\[\(]?(?P<categ>' \
                                      + classification[0].strip() + u')' \
-                                     + numeration_regexp + u'[\]\)]?)'
+                                     + numeration_regexp + ur'[\]\)]?)'
 
                 re_search_pattern = re.compile(search_pattern_str,
                                                re.UNICODE)

--- a/refextract/references/kbs/report-numbers.kb
+++ b/refextract/references/kbs/report-numbers.kb
@@ -181,6 +181,8 @@ CMS CR                 ---CMS-CR
 CMS NOTE               ---CMS-NOTE
 CMS EXO                ---CMS-EXO
 LHCB                   ---LHCB
+LHCB JOURNAL           ---LHCB-JOURNAL
+LHCB ANA               ---LHCB-ANA
 SN ATLAS               ---SN-ATLAS
 PAS SUSY               ---CMS-PAS-SUS
 CMS PAS EXO            ---CMS-PAS-EXO
@@ -303,3 +305,9 @@ ANL HEP TR   ---ANL-HEP-TR
 ANTARES SOFT  ---ANTARES-SOFT
 ANTARES PHYS  ---ANTARES-Phys
 ANTARES OPMO  ---ANTARES-Opmo
+
+
+*****LIGO*****
+< Tyy9999 00 a>
+
+LIGO---LIGO

--- a/refextract/references/record.py
+++ b/refextract/references/record.py
@@ -117,7 +117,11 @@ def build_reference_fields(citation_elements, line_marker, reference_format):
 
         # DOI
         elif element['type'] == "DOI":
-            add_subfield(current_field, 'doi', element['doi_string'])
+            add_subfield(current_field, 'doi', 'doi:' + element['doi_string'])
+
+        # HDL
+        elif element['type'] == "HDL":
+            add_subfield(current_field, 'hdl', 'hdl:' + element['hdl_id'])
 
         # AUTHOR
         elif element['type'] == "AUTH":

--- a/refextract/references/tag.py
+++ b/refextract/references/tag.py
@@ -470,7 +470,7 @@ def find_numeration_more(line):
             return {'year': info.get('year', None),
                     'series': series,
                     'volume': info['vol_num'],
-                    'page': info['page'],
+                    'page': info['page'] or info['jinst_page'],
                     'page_end': info['page_end'],
                     'len': len(info['aftertitle'])}
 
@@ -556,7 +556,7 @@ def extract_series_from_volume(volume):
     for p in patterns:
         match = p.search(volume)
         if match:
-            return match.group(1)
+            return match.group(1).upper()
     return None
 
 
@@ -1116,7 +1116,7 @@ def find_numeration(line):
             return {'year': info.get('year', None),
                     'series': series,
                     'volume': info['vol_num'],
-                    'page': info['page'],
+                    'page': info['page'] or info['jinst_page'],
                     'page_end': info['page_end'],
                     'len': match.end()}
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = [
 ]
 
 test_requirements = [
-    'coverage>=3.7.1,<4.0a1',
+    'coverage>=3.7.1',
     'pytest>=2.7.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',


### PR DESCRIPTION
* Accepts Publications as reference section.
* Refactors book handling.
* Adds LIGO report numbers to the kb.
* Adds tweaks to book recognition.
* Adds the filename of the extracted files in the 999C6f field.
* Converts arXiv urls to report numbers.
* Handles hdls.
* Introduces selective ref section title detection: we now set a
  priority on which title form is the most important.
  References will be given priority over anything else while
  Reference will ranked last with Bibliography in between.
  That means that if "Bibliography" is found in the text, we assume it
  is the reference section and we don't look for a section titles
  "Reference".
* Handles lower case volume letters.
* Adds 2 lhcp report numbers.
* Supports non ascii chars in build_journals_kb().
* Introduces support for JINST (and some other journals) article IDs
  which starts with P, where the P is actually part of the ID itself,
  and must not be stripped.
* Supports JCAP/JHEP 3digit pages.
* Improves the API function `extract_journal_references` to use
  a higher level API function of `refextract_engine.py` in order to
  benefit from additional massaging of reference data.
* No longer matches ambiguous references.

Signed-off-by: Alessio Deiana <alessio.deiana@cern.ch>
Co-authored-by: Samuele Kaplun <samuele.kaplun@cern.ch>
Co-authored-by: Jan Aage Lavik <jan.age.lavik@cern.ch>
Co-authored-by: Javier Martin Montull <javier.martin.montull@cern.ch>