### PR TITLE
Add link to github repository in README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Small library for extracting references used in scholarly communication.
 
 * Free software: GPLv2
 * Documentation: http://pythonhosted.org/refextract/
+* Issues and pull requests: https://github.com/inspirehep/refextract
 
 *Originally exported from Invenio https://github.com/inveniosoftware/invenio.*
 


### PR DESCRIPTION
I came across http://pythonhosted.org/refextract/ but it didn't list the associated github repository. This should take care of it.