### PR TITLE
references: matches more DOIs

### DIFF
--- a/refextract/references/regexs.py
+++ b/refextract/references/regexs.py
@@ -648,13 +648,13 @@ re_numeration_yr_vol_page = re.compile(
 # This pattern matches both url (http) and 'doi:' or 'DOI' formats
 re_doi = (re.compile(ur"""
     ((\(?[Dd][Oo][Ii](\s)*\)?:?(\s)*)       # 'doi:' or 'doi' or '(doi)' (upper or lower case)
-    |(https?://dx\.doi\.org\/))?            # or 'http://dx.doi.org/'    (neither has to be present)
-    (10\.                                   # 10.                        (mandatory for DOI's)
+    |(https?://(dx\.)?doi\.org\/))?         # or 'http://(dx.)doi.org/'  (neither has to be present)
+    (?P<doi>10\.                            # 10.                        (mandatory for DOI's)
     \d{4}                                   # [0-9] x4
-    /                                       # /
+    (/|%2f)                                 # / (possibly urlencoded)
     [\w\-_:;\(\)/\.<>]+                     # any character
     [\w\-_:;\(\)/<>])                       # any character excluding a full stop
-    """, re.VERBOSE))
+    """, re.VERBOSE + re.IGNORECASE))
 
 # Pattern used to locate HDL (handle identifiers)
 re_hdl = re.compile(ur"""([hH][dD][lL]:

--- a/refextract/references/tag.py
+++ b/refextract/references/tag.py
@@ -23,6 +23,8 @@
 
 import re
 
+from urlparse import unquote
+
 from unidecode import unidecode
 
 from .config import \
@@ -1419,7 +1421,9 @@ def identify_and_tag_DOI(line):
         start = match.start()
         end = match.end()
         # Get the actual DOI string (remove the url part of the doi string)
-        doi_phrase = match.group(6)
+        doi_phrase = match.group('doi')
+        if '%2f' in doi_phrase.lower():
+            doi_phrase = unquote(doi_phrase)
 
         # Replace the entire matched doi with a tag
         line = line[0:start] + "<cds.DOI />" + line[end:]


### PR DESCRIPTION
* Matches DOIs that are urlencoded.

* Matches DOIs with http://doi.org/ prefix.

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>