### PR TITLE
api: also return raw references

### DIFF
--- a/refextract/references/record.py
+++ b/refextract/references/record.py
@@ -27,9 +27,7 @@ def format_marker(line_marker):
 
 
 def build_references(citations, reference_format=False):
-    """Build marc xml from a references list
-
-    Transform the reference elements into marc xml
+    """Build list of reference dictionaries from a references list
     """
     # Now, run the method which will take as input:
     # 1. A list of lists of dictionaries, where each dictionary is a piece
@@ -43,6 +41,7 @@ def build_references(citations, reference_format=False):
             for elements in citation_elements['elements']
             for c in build_reference_fields(elements,
                                             citation_elements['line_marker'],
+                                            citation_elements['raw_ref'],
                                             reference_format)]
 
 
@@ -67,7 +66,8 @@ def create_reference_field(line_marker):
     return field
 
 
-def build_reference_fields(citation_elements, line_marker, reference_format):
+def build_reference_fields(citation_elements, line_marker, raw_ref,
+                           reference_format):
     """Create the final representation of the reference information.
 
     @param citation_elements: (list) an ordered list of dictionary elements,
@@ -75,11 +75,13 @@ def build_reference_fields(citation_elements, line_marker, reference_format):
                               piece of information from a reference line.
     @param line_marker: (string) The line marker for this single reference
                         line (e.g. [19])
-    @return xml_line: (string) The MARC-XML representation of the list of
+    @param raw_ref: (string) The raw string of this line
+    @return reference_fields: (list) A list of one dictionary containing the
                       reference elements
     """
     # Begin the datafield element
     current_field = create_reference_field(line_marker)
+    current_field['raw_ref'] = [raw_ref]
 
     reference_fields = [current_field]
 

--- a/refextract/references/text.py
+++ b/refextract/references/text.py
@@ -215,8 +215,7 @@ def rebuild_reference_lines(ref_sectn, ref_line_marker_ptn):
         working_line = ""
         for l in working_ref:
             working_line = join_lines(working_line, l.strip())
-        working_line = working_line.rstrip()
-        return wash_and_repair_reference_line(working_line)
+        return working_line.rstrip()
 
     lower_case_start = re.compile(ur'[a-z]')
     continuing_line_markers = re.compile(ur'[,&-]$')

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -36,7 +36,6 @@ from refextract.references.text import wash_and_repair_reference_line
 
 
 def get_references(ref_line, override_kbs_files=None):
-    ref_line = wash_and_repair_reference_line(ref_line)
     return parse_references([ref_line], override_kbs_files=override_kbs_files)
 
 
@@ -44,47 +43,62 @@ def test_month_with_year():
     ref_line = u"""[2] S. Weinberg, A Model of Leptons, Phys. Rev. Lett. 19 (Nov, 1967) 1264–1266."""
     res = get_references(ref_line)
     references = res[0]
-    assert len(references) == 1
-    assert references[0]['author'] == [u'S. Weinberg, A Model of Leptons']
-    assert references[0]['journal_page'] == [u'1264-1266']
-    assert references[0]['journal_reference'] == [u'Phys. Rev. Lett. 19 (1967) 1264-1266']
-    assert references[0]['journal_title'] == [u'Phys. Rev. Lett.']
-    assert references[0]['journal_volume'] == [u'19']
-    assert references[0]['journal_year'] == [u'1967']
-    assert references[0]['linemarker'] == [u'2']
-    assert references[0]['year'] == [u'1967']
+    expected = [
+        {
+            'author': [u'S. Weinberg, A Model of Leptons'],
+            'journal_page': [u'1264-1266'],
+            'journal_reference': [u'Phys. Rev. Lett. 19 (1967) 1264-1266'],
+            'journal_title': [u'Phys. Rev. Lett.'],
+            'journal_volume': [u'19'],
+            'journal_year': [u'1967'],
+            'linemarker': [u'2'],
+            'year': [u'1967'],
+            'raw_ref': [ref_line],
+        }
+    ]
+    assert references == expected
 
 
 def test_numeration_not_finding_year():
     ref_line = u"""[137] M. Papakyriacou, H. Mayer, C. Pypen, H. P. Jr., and S. Stanzl-Tschegg, “Inﬂuence of loading frequency on high cycle fatigue properties of b.c.c. and h.c.p. metals,” Materials Science and Engineering, vol. A308, pp. 143–152, 2001."""
     res = get_references(ref_line)
     references = res[0]
-    assert len(references) == 1
-    assert references[0]['author'] == [u'M. Papakyriacou, H. Mayer, C. Pypen, H. P. Jr., and S. Stanzl-Tschegg']
-    assert references[0]['journal_page'] == [u'143-152']
-    assert references[0]['journal_reference'] == [u'Mat.Sci.Eng. A308 (2001) 143-152']
-    assert references[0]['journal_title'] == [u'Mat.Sci.Eng.']
-    assert references[0]['journal_volume'] == [u'A308']
-    assert references[0]['journal_year'] == [u'2001']
-    assert references[0]['linemarker'] == [u'137']
-    assert references[0]['year'] == [u'2001']
-    assert references[0]['title'] == [u'Influence of loading frequency on high cycle fatigue properties of b.c.c. and h.c.p. metals']
+    expected = [
+        {
+            'author': [u'M. Papakyriacou, H. Mayer, C. Pypen, H. P. Jr., and S. Stanzl-Tschegg'],
+            'journal_page': [u'143-152'],
+            'journal_reference': [u'Mat.Sci.Eng. A308 (2001) 143-152'],
+            'journal_title': [u'Mat.Sci.Eng.'],
+            'journal_volume': [u'A308'],
+            'journal_year': [u'2001'],
+            'linemarker': [u'137'],
+            'year': [u'2001'],
+            'title': [u'Influence of loading frequency on high cycle fatigue properties of b.c.c. and h.c.p. metals'],
+            'raw_ref': [ref_line],
+        }
+    ]
+    assert references == expected
 
 
 def test_numeration_not_finding_year2():
     ref_line = u"""[138] Y.-B. Park, R. Mnig, and C. A. Volkert, “Frequency effect on thermal fatigue damage in Cu interconnects,” Thin Solid Films, vol. 515, pp. 3253– 3258, 2007."""
     res = get_references(ref_line)
     references = res[0]
-    assert len(references) == 1
-    assert references[0]['author'] == [u'Y.-B. Park, R. Mnig, and C. A. Volkert']
-    assert references[0]['journal_page'] == [u'3253-3258']
-    assert references[0]['journal_reference'] == [u'Thin Solid Films 515 (2007) 3253-3258']
-    assert references[0]['journal_title'] == [u'Thin Solid Films']
-    assert references[0]['journal_volume'] == [u'515']
-    assert references[0]['journal_year'] == [u'2007']
-    assert references[0]['linemarker'] == [u'138']
-    assert references[0]['year'] == [u'2007']
-    assert references[0]['title'] == [u'Frequency effect on thermal fatigue damage in Cu interconnects']
+    expected = [
+        {
+            'author': [u'Y.-B. Park, R. Mnig, and C. A. Volkert'],
+            'journal_page': [u'3253-3258'],
+            'journal_reference': [u'Thin Solid Films 515 (2007) 3253-3258'],
+            'journal_title': [u'Thin Solid Films'],
+            'journal_volume': [u'515'],
+            'journal_year': [u'2007'],
+            'linemarker': [u'138'],
+            'year': [u'2007'],
+            'title': [u'Frequency effect on thermal fatigue damage in Cu interconnects'],
+            'raw_ref': [ref_line],
+        }
+    ]
+    assert references == expected
 
 
 def test_extra_a_in_report_number():
@@ -104,6 +118,7 @@ def test_extra_a_in_report_number():
         u'ATLAS-CONF-2012-078',
     ]
     assert references[0]['linemarker'] == [u'14']
+
 
 def test_get_plaintext_document_body(tmpdir):
     input = [u"Some text\n", u"on multiple lines\n"]


### PR DESCRIPTION
* NEW the parsed reference dictionary returned by the API now also
contains the `raw_ref` key containing the unparsed line from which that
reference was extracted.
* This required some refactoring of refextract to be possible.
* Also corrects a bug with collaboration deduplicaton.

Signed-off-by: Micha Moskovic <michamos@gmail.com>