### PR TITLE
made CFG_PATH_GFILE and CFG_PATH_PDFTOTEXT configurable from the environment

### DIFF
--- a/refextract/references/config.py
+++ b/refextract/references/config.py
@@ -26,6 +26,8 @@
 
 from __future__ import unicode_literals
 
+import os
+
 try:
     from shutil import which
 except ImportError:
@@ -35,8 +37,8 @@ except ImportError:
 import pkg_resources
 
 # Version number:
-CFG_PATH_GFILE = which("file")
-CFG_PATH_PDFTOTEXT = which("pdftotext")
+CFG_PATH_GFILE = os.environ.get('CFG_PATH_GFILE', which("file"))
+CFG_PATH_PDFTOTEXT = os.environ.get('CFG_PATH_PDFTOTEXT', which("pdftotext"))
 
 # Module config directory
 CFG_KBS_DIR = pkg_resources.resource_filename('refextract.references', 'kbs')


### PR DESCRIPTION
In order to containerize refextract for use in a web service, I needed to be able to explicitly specify the location of the ``pdftotext`` binary. So I altered ``refextract/references/config.py`` slightly so that the environment variables ``CFG_PATH_GFILE`` and ``CFG_PATH_PDFTOTEXT`` are preferred over ``shutil.which``. This may be relevant for #9.