### PR TITLE
global: remove GarbageFullTextError

### DIFF
--- a/refextract/documents/pdf.py
+++ b/refextract/documents/pdf.py
@@ -43,7 +43,6 @@ import subprocess
 from six import iteritems
 
 from ..references.config import CFG_PATH_PDFTOTEXT
-from ..references.errors import GarbageFullTextError
 
 # a dictionary of undesirable characters and their replacements:
 UNDESIRABLE_CHAR_REPLACEMENTS = {
@@ -450,38 +449,11 @@ def replace_undesirable_characters(line):
     return line
 
 
-def pdftotext_conversion_is_bad(txtlines):
-    """Sometimes pdftotext performs a bad conversion which consists of many
-       spaces and garbage characters.
-       This method takes a list of strings obtained from a pdftotext conversion
-       and examines them to see if they are likely to be the result of a bad
-       conversion.
-       @param txtlines: (list) of unicode strings obtained from pdftotext
-        conversion.
-       @return: (integer) - 1 if bad conversion; 0 if good conversion.
-    """
-    # Numbers of 'words' and 'whitespaces' found in document:
-    numWords = numSpaces = 0
-    # whitespace character pattern:
-    p_space = re.compile(unicode(r'(\s)'), re.UNICODE)
-    # non-whitespace 'word' pattern:
-    p_noSpace = re.compile(unicode(r'(\S+)'), re.UNICODE)
-    for txtline in txtlines:
-        numWords = numWords + len(p_noSpace.findall(txtline.strip()))
-        numSpaces = numSpaces + len(p_space.findall(txtline.strip()))
-    if numSpaces >= (numWords * 3):
-        # Too many spaces - probably bad conversion
-        return True
-    else:
-        return False
-
-
 def convert_PDF_to_plaintext(fpath, keep_layout=False):
     """ Convert PDF to txt using pdftotext
 
     Take the path to a PDF file and run pdftotext for this file, capturing
     the output.
-    It raises GarbageFullTextError when this output is garbage.
     @param fpath: (string) path to the PDF file
     @return: (list) of unicode strings (contents of the PDF file translated
     into plaintext; each string is a line in the document.)
@@ -523,9 +495,5 @@ def convert_PDF_to_plaintext(fpath, keep_layout=False):
 
     print("* convert_PDF_to_plaintext found: "
           "%s lines of text" % len(doclines))
-
-    # finally, check conversion result not bad:
-    if pdftotext_conversion_is_bad(doclines):
-        raise GarbageFullTextError("Garbage fulltext in '{0}'".format(fpath))
 
     return doclines

--- a/refextract/references/api.py
+++ b/refextract/references/api.py
@@ -57,8 +57,7 @@ def extract_references_from_url(url, headers=None, chunk_size=1024, **kwargs):
     It returns a list of parsed references.
 
     It raises FullTextNotAvailableError if the URL gives a 404,
-    UnknownDocumentTypeError if it is not a PDF or plain text
-    and GarbageFullTextError if the fulltext extraction gives garbage.
+    UnknownDocumentTypeError if it is not a PDF or plain text.
 
     The standard reference format is: {title} {volume} ({year}) {page}.
 
@@ -109,9 +108,7 @@ def extract_references_from_file(path,
     The first parameter is the path to the file.
     It returns a list of parsed references.
     It raises FullTextNotAvailableError if the file does not exist,
-    UnknownDocumentTypeError if it is not a PDF or plain text
-    and GarbageFullTextError if the fulltext extraction gives garbage.
-
+    UnknownDocumentTypeError if it is not a PDF or plain text.
 
     The standard reference format is: {title} {volume} ({year}) {page}.
 

--- a/refextract/references/errors.py
+++ b/refextract/references/errors.py
@@ -29,11 +29,6 @@ class FullTextNotAvailableError(Exception):
     """Raised when we cannot access the document text."""
 
 
-class GarbageFullTextError(Exception):
-
-    """Raised when the fulltext extraction from the PDF gives garbage."""
-
-
 class UnknownDocumentTypeError(Exception):
 
     """Raised when we don't know how to handle the document's MIME type."""


### PR DESCRIPTION
(Something I was working on on the train since I had no internet...)

Jira: https://its.cern.ch/jira/browse/INSPIR-208

Remove the possibility of raising this exception as it suffered from
too many false positives. In particular every PDF that was produced
from Word was detected as being "garbage", despite the fact that some
references could be recovered from it.