### PR TITLE
global: remove CFG_PATH_GFILE

### DIFF
--- a/refextract/references/config.py
+++ b/refextract/references/config.py
@@ -37,7 +37,6 @@ except ImportError:
 import pkg_resources
 
 # Version number:
-CFG_PATH_GFILE = os.environ.get('CFG_PATH_GFILE', which('file'))
 CFG_PATH_PDFTOTEXT = os.environ.get('CFG_PATH_PDFTOTEXT', which('pdftotext'))
 
 # Module config directory

--- a/refextract/references/engine.py
+++ b/refextract/references/engine.py
@@ -43,7 +43,6 @@ from .config import (
     CFG_REFEXTRACT_MARKER_CLOSING_AUTHOR_ETAL,
     CFG_REFEXTRACT_MARKER_CLOSING_TITLE,
     CFG_REFEXTRACT_MARKER_CLOSING_SERIES,
-    CFG_PATH_GFILE
 )
 
 from .errors import UnknownDocumentTypeError


### PR DESCRIPTION
Since commit 10f0ccfb we don't depend anymore from the ``file`` utility,
so this configuration variable is no longer needed.

CC: @erickpeirson