### PR TITLE
global: add the unicode-string-literal dependency

### DIFF
--- a/refextract/references/api.py
+++ b/refextract/references/api.py
@@ -77,7 +77,7 @@ def extract_references_from_url(url, headers=None, chunk_size=1024, **kwargs):
     """
     # Get temporary filepath to download to
     filename, filepath = mkstemp(
-        suffix="_{0}".format(os.path.basename(url)),
+        suffix=u"_{0}".format(os.path.basename(url)),
     )
     os.close(filename)
 
@@ -93,7 +93,7 @@ def extract_references_from_url(url, headers=None, chunk_size=1024, **kwargs):
                 f.write(chunk)
         references = extract_references_from_file(filepath, **kwargs)
     except requests.exceptions.HTTPError:
-        raise FullTextNotAvailableError("URL not found: '{0}'".format(url)), None, sys.exc_info()[2]
+        raise FullTextNotAvailableError(u"URL not found: '{0}'".format(url)), None, sys.exc_info()[2]
     finally:
         os.remove(filepath)
     return references
@@ -127,7 +127,7 @@ def extract_references_from_file(path,
 
     """
     if not os.path.isfile(path):
-        raise FullTextNotAvailableError("File not found: '{0}'".format(path))
+        raise FullTextNotAvailableError(u"File not found: '{0}'".format(path))
 
     docbody = get_plaintext_document_body(path)
     reflines, dummy, dummy = extract_references_from_fulltext(docbody)

--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,14 @@ tests_require = [
 extras_require = {
     'docs': docs_require,
     'tests': tests_require,
+    'tests:python_version=="2.7"': [
+        'unicode-string-literal~=1.0,>=1.1',
+    ],
 }
 
 extras_require['all'] = []
 for name, reqs in extras_require.items():
-    if name not in ['all']:
+    if name not in ['all', 'tests:python_version=="2.7"']:
         extras_require['all'].extend(reqs)
 
 packages = find_packages(exclude=['docs'])


### PR DESCRIPTION
Prevents some errors while dealing with Unicode by adding the
``unicode-string-literal`` dependency, which adds an extra Flake8
check for Unicode-unsafe constructs.