### PR TITLE
api: accept journals dict in override_kbs_files

### DIFF
--- a/refextract/references/api.py
+++ b/refextract/references/api.py
@@ -203,7 +203,7 @@ def extract_journal_reference(line, override_kbs_files=None):
     Extracts the journal reference from string and parses for specific
     journal information.
     """
-    kbs = get_kbs(custom_kbs_files=override_kbs_files)
+    kbs = get_kbs(custom_kbs=override_kbs_files)
     references, dummy_m, dummy_c, dummy_co = parse_reference_line(line, kbs)
 
     for elements in references:

--- a/refextract/references/config.py
+++ b/refextract/references/config.py
@@ -41,14 +41,13 @@ CFG_KBS_DIR = pkg_resources.resource_filename('refextract.references', 'kbs')
 
 CFG_REFEXTRACT_KBS = {
     'journals': "%s/journal-titles.kb" % CFG_KBS_DIR,
-    'journals-re': "%s/journal-titles-re.kb" % CFG_KBS_DIR,
+    'journals_re': "%s/journal-titles-re.kb" % CFG_KBS_DIR,
     'report-numbers': "%s/report-numbers.kb" % CFG_KBS_DIR,
     'authors': "%s/authors.kb" % CFG_KBS_DIR,
     'collaborations': "%s/collaborations.kb" % CFG_KBS_DIR,
     'books': "%s/books.kb" % CFG_KBS_DIR,
-    'conferences': "%s/conferences.kb" % CFG_KBS_DIR,
     'publishers': "%s/publishers.kb" % CFG_KBS_DIR,
-    'special-journals': "%s/special-journals.kb" % CFG_KBS_DIR,
+    'special_journals': "%s/special-journals.kb" % CFG_KBS_DIR,
 }
 
 # Reference fields:

--- a/refextract/references/engine.py
+++ b/refextract/references/engine.py
@@ -1428,7 +1428,7 @@ def parse_references(reference_lines,
     output a list of dictionaries containing the parsed references
     """
     # RefExtract knowledge bases
-    kbs = get_kbs(custom_kbs_files=override_kbs_files)
+    kbs = get_kbs(custom_kbs=override_kbs_files)
     # Identify journal titles, report numbers, URLs, DOIs, and authors...
     processed_references, counts, dummy_bad_titles_count = \
         parse_references_elements(reference_lines, kbs, linker_callback)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,7 +76,7 @@ def kbs_override():
             ("NUCL INSTRUM METHODS", "Nucl.Instrum.Meth."),
             ("Z PHYS", "Z.Phys."),
         ],
-        "journals-re": [
+        "journals_re": [
             "DAN---Dokl.Akad.Nauk Ser.Fiz.",
         ],
         "report-numbers": [
@@ -165,3 +165,11 @@ def test_long_registrant_dois(pdf_files):
     for ref in r[1:]:
         assert 'doi' in ref
         assert ref.get('doi')[0].startswith(u'doi:10.18429/JACoW')
+
+
+def test_override_kbs_files_can_take_journals_dict():
+    journals = {"Journal of Testing": "J.Testing"}
+    reference = "J. Smith, Journal of Testing 42 (2020) 1234"
+
+    result = extract_references_from_string(reference, override_kbs_files={"journals": journals})
+    assert result[0]["journal_title"] == ["J.Testing"]

--- a/tests/test_kbs.py
+++ b/tests/test_kbs.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of refextract
+# Copyright (C) 2020 CERN.
+#
+# refextract is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# refextract is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with refextract; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from refextract.references.kbs import get_kbs
+
+
+def test_get_kbs_doesnt_override_default_if_value_is_none():
+    cache = get_kbs(custom_kbs={"journals": None})
+    assert len(cache["journals"]) == 3
+    assert "JHEP" in cache["journals"][-1]
+
+
+def test_get_kbs_caches_journal_dict():
+    journals = {"Journal of Testing": "J.Testing"}
+
+    first_cache = get_kbs(custom_kbs={"journals": journals}).copy()
+    assert len(first_cache["journals"]) == 3
+    assert ["JOURNAL OF TESTING", "J TESTING"] == first_cache["journals"][-1]
+
+    journals = journals.copy()
+    second_cache = get_kbs(custom_kbs={"journals": journals})
+    # the cache is reused, so identity of the cache elements doesn't change
+    assert all(
+        cached_first is cached_second for (cached_first, cached_second)
+        in zip(first_cache["journals"], second_cache["journals"])
+    )
+
+
+def test_get_kbs_invalidates_cache_if_input_changes():
+    journals = {"Journal of Testing": "J.Testing"}
+    first_cache = get_kbs(custom_kbs={"journals": journals}).copy()
+
+    journals = journals = {"Journal of Testing": "J.Test."}
+    second_cache = get_kbs(custom_kbs={"journals": journals})
+    # the cache is invalidated, so identity of the cache elements changes
+    assert all(
+        cached_first is not cached_second for (cached_first, cached_second)
+        in zip(first_cache["journals"], second_cache["journals"])
+    )
+    assert len(second_cache["journals"]) == 3
+    assert ["JOURNAL OF TESTING", "J TEST"] == second_cache["journals"][-1]


### PR DESCRIPTION
* The `journals` key of the `override_kbs_files` parameter of API
  functions can now be a `dict` mapping unnormalized journal name to
  normalized journal name, which allows stable caching without sorting.
* The caching mechanism has been changed to be more fine-grained and
  properly invalidate the cache (fixing a memory leak).
* ref inspirehep/inspirehep#1289.

Signed-off-by: Micha Moskovic <michamos@gmail.com>
Sem-ver: new feature