### PR TITLE
fix: use lower_right instead of right

### DIFF
--- a/refextract/references/pdf.py
+++ b/refextract/references/pdf.py
@@ -226,7 +226,9 @@ def _destination_position(pdf, destination):
     This representation is useful for sorting named destinations and
     assumes the text has at most 2 columns
     """
-    pagewidth = pdf.pages[pdf.get_destination_page_number(destination)].cropbox.right
+    pagewidth = pdf.pages[
+        pdf.get_destination_page_number(destination)
+    ].cropbox.lower_right[0]
     if not destination.left or not destination.top:
         raise IncompleteCoordinatesError(destination)
     # assuming max 2 columns
@@ -246,7 +248,7 @@ def _uri_position(pdf, uri_destination):
     page_nb = uri_destination.get("page_nb")
     destintation_left = uri_destination["/Rect"][0]
     destintation_top = uri_destination["/Rect"][3]
-    pagewidth = pdf.get_page(page_nb).cropbox.right
+    pagewidth = pdf.get_page(page_nb).cropbox.lower_right[0]
     column = (2 * destintation_left) // pagewidth
     # neccessary to exclude column from sorting
     return (page_nb, column, -destintation_top, destintation_left)


### PR DESCRIPTION
as before we were using `lowerRight[0]`
https://github.com/inspirehep/refextract/blob/4dbe77d4b1c2d76868fb9473a6c9fa06fdc3a1b8/refextract/references/pdf.py#L227
we should now use `lower_right[0]` https://pypdf.readthedocs.io/en/stable/modules/RectangleObject.html#pypdf.generic.RectangleObject.lower_right

instead of `.right` - https://github.com/py-pdf/pypdf/blob/main/docs/user/migration-1-to-2.md?plain=1#L139 .

Just to be 110% sure its the same, behaviour